### PR TITLE
Add `noEmit: false` to server config for build task

### DIFF
--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "module": "commonjs",
-    "target": "es6"
+    "target": "es6",
+    "noEmit": false
   },
   "include": ["server/**/*.ts"]
 }


### PR DESCRIPTION
When creating a server build, I am currently experiencing a non-existent `build` folder. With this PR, the `build` folder is now existent again, and the server can be deployed to Heroku and other platforms.